### PR TITLE
 Add 'Phils Lab' to list of youtube channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ videos where he replies to any question from the watchers.
 * [Andreas Spiess](https://www.youtube.com/channel/UCu7_D0o48KbfhpEohoP7YSQ) Projects and comparison of electronic devices.
 * [Jeremy Blum](https://www.youtube.com/user/sciguy14) Amazing Arduino tutorial series and projects.
 * [Proto G](https://www.youtube.com/user/garofalo42) Yet another interesting channel with lots of great projects.
+* [Phils Lab](https://www.youtube.com/c/PhilS94) Analog and digital electronics design, PCB design, control systems, digital signal processing, STM32, KiCad, RF, etc.
 
 ### Podcasts   <a name="Podcasts"></a>
 * [Internet of Things](https://iotpodcast.com/) Hosted by Stacey Higginbotham they discuss IoT topics and news


### PR DESCRIPTION
**WHAT**
Add [Phils' Lab](https://www.youtube.com/c/PhilS94) to list of youtube channels.

**WHY**
[Phils' Lab](https://www.youtube.com/c/PhilS94) and his associated website [Philsal](https://philsal.co.uk/) is an amazing resource for those of us getting into board design using things like STM32 micros, designing boards using KiCad, and the intricacies of protecting from ESD, RF noise, USB, etc.